### PR TITLE
RedTubePlugin.php Make sure the URL has http:

### DIFF
--- a/src/RedTubePlugin.php
+++ b/src/RedTubePlugin.php
@@ -33,6 +33,8 @@ class RedTubePlugin extends AbstractPlugin {
 		
 			$video = rawurldecode(stripslashes($matches[0][2]));
 			
+			$video = (preg_match('/^\/\//is', $video)) ? "http:".$video : $video;
+			
 			// generate player
 			$player = vid_player($video, 973, 547, 'mp4');
 			


### PR DESCRIPTION
Sometimes the video URL starts with // and it fails to load in the player, here is a fix:

`$video = (preg_match('/^\/\//is', $video)) ? "http:".$video : $video;`