### PR TITLE
Updated Flowplayer CDN (much faster)

### DIFF
--- a/src/utils.php
+++ b/src/utils.php
@@ -30,7 +30,7 @@ function vid_player($url, $width, $height, $extension = false){
 		// encode before embedding it into player's parameters
 		$video_url = rawurlencode($video_url);
 	
-		$html = '<object id="flowplayer" width="'.$width.'" height="'.$height.'" data="//releases.flowplayer.org/swf/flowplayer-3.2.18.swf" type="application/x-shockwave-flash">
+		$html = '<object id="flowplayer" width="'.$width.'" height="'.$height.'" data="//cdnjs.cloudflare.com/ajax/libs/flowplayer/5.4.6/flowplayer.swf" type="application/x-shockwave-flash">
  	 
        	<param name="allowfullscreen" value="true" />
 		<param name="wmode" value="transparent" />


### PR DESCRIPTION
Sometimes releases.flowplayer.org (HTTP) takes some time to load the swf file, maybe better to use directly https://releases.flowplayer.org...